### PR TITLE
Removed duplicate Description key from template parameter

### DIFF
--- a/deployment/centralized-logging-primary.template
+++ b/deployment/centralized-logging-primary.template
@@ -17,7 +17,6 @@ Parameters:
 
   # Email address for the Elasticsearch domain admin
   DomainAdminEmail:
-    Description: The email address of the Elasticsearch domain admin who will receive CloudWatch alarm notifications.
     Type: String
     Default: esdomainadmin@example.com
     AllowedPattern: '^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$'


### PR DESCRIPTION
*Description of changes:*
Based on **[cfn-lint] E0000** duplicate keys can't be present. There was an instance of a duplicate Description key in one of the parameter fields **DomainAdminEmail**

It does appear that the tests don't pick up on issues like this when it runs. Unsure if maybe its worth doing linting analysis as part of the `npm test` phase.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
