### PR TITLE
Updated ClusterSize Parameter description

### DIFF
--- a/deployment/centralized-logging-primary.template
+++ b/deployment/centralized-logging-primary.template
@@ -32,7 +32,7 @@ Parameters:
 
   # ES cluster size
   ClusterSize:
-    Description: Amazon ES cluster size; small (2 data nodes), medium (4 data nodes), large (10 data nodes)
+    Description: Amazon ES cluster size; small (4 data nodes), medium (6 data nodes), large (6 data nodes)
     Type: String
     Default: Small
     AllowedValues:


### PR DESCRIPTION
*Description of changes:*

The number of data nodes deployed for the different cluster sizes was changed in v2.2.0.

This change updates the description of the ClusterSize parameter to match the number of data which are actually deployed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
