### PR TITLE
Remove unused instance types from InstanceMap

### DIFF
--- a/deployment/centralized-logging-primary.template
+++ b/deployment/centralized-logging-primary.template
@@ -114,22 +114,6 @@ Metadata:
 
 Mappings:
   InstanceMap:
-    t2.micro: {"Arch":"HVM64"}
-    us-east-1: {"instancetype":"t2.micro"}
-    us-east-2: {"instancetype":"t2.micro"}
-    us-west-1: {"instancetype":"t2.micro"}
-    us-west-2: {"instancetype":"t2.micro"}
-    ca-central-1: {"instancetype":"t2.micro"}
-    eu-west-1: {"instancetype":"t2.micro"}
-    eu-central-1: {"instancetype":"t2.micro"}
-    eu-west-2: {"instancetype":"t2.micro"}
-    eu-west-3: {"instancetype":"t2.micro"}
-    ap-southeast-1: {"instancetype":"t2.micro"}
-    ap-southeast-2: {"instancetype":"t2.micro"}
-    ap-northeast-1: {"instancetype":"t2.micro"}
-    ap-northeast-2: {"instancetype":"t2.micro"}
-    ap-south-1: {"instancetype":"t2.micro"}
-    sa-east-1: {"instancetype":"t2.micro"}
     send-data: {"SendAnonymousData": "Yes"}
 
   # V57271571 - 10/09/2018 - update tshirt size


### PR DESCRIPTION
*Description of changes:*

Removes the per-region instance types from the InstanceMap mapping. References to these were removed in v2.2.0 so these values aren't being used anymore

For example, see https://github.com/awslabs/aws-centralized-logging/commit/740cd6988d9ca105b8a11dcd742b133eb21f57ba#diff-da34860067cdbd6aae351691d78328f6L488

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
