### PR TITLE
update path building for HelperLambda CLTransformer to remain relativ…

### DIFF
--- a/source/resources/lib/cl-primary-stack.ts
+++ b/source/resources/lib/cl-primary-stack.ts
@@ -91,6 +91,7 @@ import { Queue, QueueEncryption } from "@aws-cdk/aws-sqs";
 import { Topic } from "@aws-cdk/aws-sns";
 import { Alias, IAlias } from "@aws-cdk/aws-kms";
 import { EmailSubscription } from "@aws-cdk/aws-sns-subscriptions";
+import path from 'path';
 
 enum LogLevel {
   ERROR = "error",
@@ -388,7 +389,12 @@ export class CLPrimary extends Stack {
         SEND_METRIC: metricsMap.findInMap("Metric", "SendAnonymousMetric"),
       },
       handler: "index.handler",
-      code: Code.fromAsset("../../source/services/helper/dist/cl-helper.zip"),
+      code: Code.fromAsset(
+        path.join(
+          __dirname, 
+          "../../services/helper/dist/cl-helper.zip"
+        )
+      ),
       runtime: Runtime.NODEJS_12_X,
       timeout: Duration.seconds(300),
       role: helperRole,
@@ -827,7 +833,10 @@ export class CLPrimary extends Stack {
       },
       handler: "index.handler",
       code: Code.fromAsset(
-        "../../source/services/transformer/dist/cl-transformer.zip"
+        path.join(
+          __dirname,
+          "../../services/transformer/dist/cl-transformer.zip"
+        )
       ),
       runtime: Runtime.NODEJS_12_X,
       timeout: Duration.seconds(300),


### PR DESCRIPTION
**background**
We're attempting to integrate this solution into an existing CDK project. Unfortunately, it's not packaged as a Cdk Pattern/Construct. In order to use it without creating a fork and making it difficult to update in the future we've created a dir structure like
```
/our-project-root
  /aws-centralized-logging <-- pristine solution @ latest commit
  /our-modifications
     /bin <---our updated entrypoint
```
Our custom entrypoint creates an instance of the `cl-primary-stack.ts` from the `aws-centralized-logging` dir and then references some of its resources (vpn, etc) to build out additional resources.

*the problem**  
If I run `cdk ls` from our new root dir and target our entrypoint it fails due to paths being built without joining relative to `__dirname`. ie)
```
Code.fromAsset("../../source/services/helper/dist/cl-helper.zip")
```


*Description of changes:*
I have updated the path building for the `CLTransformer` and `HelperLambda` to start from `__dirname`
